### PR TITLE
Bump org.slf4j:slf4j-simple from 2.0.7 to 2.0.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler>3.8.0</maven.compiler>
         <maven-jar>3.3.0</maven-jar>
-        <slf4j.version>2.0.7</slf4j.version>
+        <slf4j.version>2.0.9</slf4j.version>
         <testng.version>7.8.0</testng.version>
         <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
     </properties>


### PR DESCRIPTION
Bumps org.slf4j:slf4j-simple from 2.0.7 to 2.0.9.

---
updated-dependencies:
- dependency-name: org.slf4j:slf4j-simple dependency-type: direct:production update-type: version-update:semver-patch ...